### PR TITLE
Add initial API Gateway configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# NGINX 기본 이미지를 기반으로 함
+FROM nginx:latest
+
+# NGINX 설정 파일 복사
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# NGINX 실행
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -20,7 +20,7 @@ http {
 
     server {
         listen 80;
-        // TODO: SSL 지원
+        # TODO: SSL 지원
 
         # 인증이 불필요한 엔드포인트 라우팅
         location /api/user/login/ {

--- a/nginx.conf
+++ b/nginx.conf
@@ -28,17 +28,22 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
-        location /api/user/register/ {
+        location /api/user/register/email-check/ {
             proxy_pass http://user_service;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
-        location /api/user/verify-email/ {
+        location /api/user/register/nickname-check/ {
             proxy_pass http://user_service;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
-
+        location /api/user/register/complete/ {
+            proxy_pass http://user_service;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+       
         # 인증이 필요한 모든 요청
         location / {
             # JWT 검증을 위해 auth 서비스로 요청 전달

--- a/nginx.conf
+++ b/nginx.conf
@@ -20,21 +20,21 @@ http {
 
     server {
         listen 80;
-        //TODO: SSL 지원
+        // TODO: SSL 지원
 
         # 인증이 불필요한 엔드포인트 라우팅
         location /api/user/login/ {
-            proxy_pass http://auth_service;
+            proxy_pass http://user_service;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
         location /api/user/register/ {
-            proxy_pass http://auth_service;
+            proxy_pass http://user_service;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
         location /api/user/verify-email/ {
-            proxy_pass http://auth_service;
+            proxy_pass http://user_service;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,61 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream auth_service {
+        server auth:8000;
+    }
+    upstream user_service {
+        server user:8001;
+    }
+    upstream chat_service {
+        server chat:8002;
+    }
+    upstream game_service {
+        server game:8003;
+    }
+
+    server {
+        listen 80;
+        //TODO: SSL 지원
+
+        # 인증이 불필요한 엔드포인트 라우팅
+        location /api/user/login/ {
+            proxy_pass http://auth_service;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+        location /api/user/register/ {
+            proxy_pass http://auth_service;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+        location /api/user/verify-email/ {
+            proxy_pass http://auth_service;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        # 인증이 필요한 모든 요청
+        location / {
+            # JWT 검증을 위해 auth 서비스로 요청 전달
+            proxy_pass http://auth_service;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+
+            # 검증 성공 시 적절한 서비스로 라우팅
+            location /user/ {
+                proxy_pass http://user_service;
+            }
+            location /chat/ {
+                proxy_pass http://chat_service;
+            }
+            location /game/ {
+                proxy_pass http://game_service;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 관련된 이슈 번호

## 주요 구현 사항

- NGINX 기반 API Gateway 초기 설정 추가.
- NGINX에서 인증이 불필요한 엔드포인트를 `auth` 서비스로 라우팅하고, 나머지 요청을 검증 후 적절한 서비스로 라우팅하도록 설정.
- Dockerfile과 NGINX 설정 파일을 포함.

## 리뷰어 참고 사항