### PR TITLE
CORS 헤더를 위한 별도의 설정 파일 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
 
 # NGINX 설정 파일 복사
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY cors-headers.conf /etc/nginx/common/cors-headers.conf
 COPY var/www/media/avatars var/www/media/avatars
 RUN chmod -R 755 /var/www/media/avatars
 

--- a/cors-headers.conf
+++ b/cors-headers.conf
@@ -1,0 +1,16 @@
+# OPTIONS 요청 처리
+if ($request_method = 'OPTIONS') {
+    add_header 'Access-Control-Allow-Origin' '*';
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
+    add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization, X-Requested-With';
+    add_header 'Access-Control-Allow-Credentials' 'true';
+    return 204;
+}
+
+if ($request_method != 'OPTIONS') {
+    # 공통 CORS 설정
+    add_header 'Access-Control-Allow-Origin' '*';
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
+    add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization, X-Requested-With';
+    add_header 'Access-Control-Allow-Credentials' 'true';
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,103 @@
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream user {
+        server user:8000;
+    }
+    upstream chat {
+        server chat:8000;
+    }
+    upstream game {
+        server game:8000;
+    }
+
+    # 1) HTTPS 서버 블록 (443)
+    server {
+        listen 443 ssl;
+
+        # SSL 인증서
+        ssl_certificate /etc/nginx/ssl/selfsigned.crt;
+        ssl_certificate_key /etc/nginx/ssl/selfsigned.key;
+        ssl_protocols TLSv1.2 TLSv1.3;
+
+        #TODO: 공통 CSP 설정
+
+        location / {
+            location /media/avatars/default.png {
+                include /etc/nginx/common/cors-headers.conf;
+                alias /media/avatars/default.png;
+                try_files $uri $uri/ = 404;
+            }
+            location /media/avatars/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_pass http://user;
+                proxy_set_header Host api-gateway;
+                proxy_set_header X-Real-IP $remote_addr;
+            }
+            location /api/user/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_pass http://user;
+				proxy_set_header Host api-gateway;
+            	proxy_set_header X-Real-IP $remote_addr;
+            }
+            location /api/chat/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_pass http://chat;
+				proxy_set_header Host api-gateway;
+            	proxy_set_header X-Real-IP $remote_addr;
+            }
+            location /api/game/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_pass http://game;
+				proxy_set_header Host api-gateway;
+            	proxy_set_header X-Real-IP $remote_addr;
+            }
+			location /ws/user/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_http_version 1.1;
+				proxy_set_header Upgrade $http_upgrade;
+				proxy_set_header Connection "upgrade";
+				proxy_read_timeout 86400;
+
+				# 쿼리스트링을 포함하여 전달
+				proxy_pass http://user$request_uri;
+				proxy_set_header Host api-gateway;
+				proxy_set_header X-Real-IP $remote_addr;
+            }
+			location /ws/chat/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_http_version 1.1;
+				proxy_set_header Upgrade $http_upgrade;
+				proxy_set_header Connection "upgrade";
+				proxy_read_timeout 86400;
+
+				# 쿼리스트링을 포함하여 전달
+				proxy_pass http://chat$request_uri;
+				proxy_set_header Host api-gateway;
+				proxy_set_header X-Real-IP $remote_addr;
+            }
+			location /ws/game/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_http_version 1.1;
+				proxy_set_header Upgrade $http_upgrade;
+				proxy_set_header Connection "upgrade";
+				proxy_read_timeout 86400;
+
+				# 쿼리스트링을 포함하여 전달
+				proxy_pass http://game$request_uri;
+				proxy_set_header Host api-gateway;
+				proxy_set_header X-Real-IP $remote_addr;
+            }
+        }
+    }
+
+    # 2) HTTP -> HTTPS 리다이렉트
+    server {
+        listen 80;
+        return 301 https://$host$request_uri;
+    }
+}


### PR DESCRIPTION
## ✨ 변경 내용
- CORS 지원을 위한 NGINX 설정 추가
  - OPTIONS 메소드 처리 로직 구현 (204 No Content 응답)
  - 모든 요청에 CORS 헤더 추가

## 🛠 주요 변경 파일
- `cors-headers.conf`: CORS 헤더 및 OPTIONS 요청 처리 로직 추가
- `nginx.conf`: 각 위치 블록에 CORS 설정 적용

## 🔍 테스트 사항 (배포 후 확인해야 하는 사항들 목록)
1. **OPTIONS 요청 테스트**
   - `/api/user/login/`로 OPTIONS 요청 → HTTP 204 응답 확인
   - `/api/user/register/`로 OPTIONS 요청 → HTTP 204 응답 확인
   - `/api/chat/`, `/api/game/` 경로로 OPTIONS 요청 → HTTP 204 응답 확인

2. **CORS 동작 확인**
   - 모든 엔드포인트에서 `Access-Control-Allow-*` 헤더가 올바르게 설정되는지 확인
   - Preflight 요청이 backend로 전달되지 않고 NGINX에서 직접 처리되는지 확인
   - 웹소켓 연결시에도 CORS 헤더가 올바르게 적용되는지 확인

3. **웹소켓 연결 확인**
   - `/ws/user/`, `/ws/chat/`, `/ws/game/` 경로로 웹소켓 연결 정상 동작 확인
   - 업그레이드 헤더와 함께 요청시 프록시 설정이 올바르게 적용되는지 확인

## ✅ 체크리스트
- [x] CORS 헤더가 모든 라우트에 올바르게 적용되었는지 확인
- [ ] 기존 API 요청이 CORS 변경 후에도 정상 동작하는지 확인
- [ ] 웹소켓 연결이 CORS 변경 후에도 정상 동작하는지 확인

## 🚀 리뷰어에게 요청사항
- OPTIONS 처리 로직의 위치와 적합성 확인 부탁드립니다.
- `Access-Control-Allow-Origin` 값을 '*' 대신 특정 도메인으로 제한해야 할지 의견 부탁드립니다.