### PR TITLE
Add frontend routing to Nginx configuration

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -14,6 +14,9 @@ http {
     upstream game {
         server game:8000;
     }
+    upstream frontend {
+        server frontend:3000;
+    }
 
     # 1) HTTPS 서버 블록 (443)
     server {
@@ -27,6 +30,8 @@ http {
         #TODO: 공통 CSP 설정
 
         location / {
+            try_files $uri @frontend;
+
             location /media/avatars/default.png {
                 include /etc/nginx/common/cors-headers.conf;
                 alias /media/avatars/default.png;
@@ -92,6 +97,13 @@ http {
 				proxy_set_header Host api-gateway;
 				proxy_set_header X-Real-IP $remote_addr;
             }
+        }
+        location @frontend {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
 


### PR DESCRIPTION
## ✨ 변경 내용
- 프론트엔드 서비스를 위한 upstream 추가 (frontend:3000)
- 루트 경로(/)에 try_files를 사용하여 프론트엔드로 폴백 설정
- 프론트엔드 서비스로 요청을 전달하기 위한 named location ('@'frontend) 구현
- 필요한 프록시 헤더 설정 추가