### PR TITLE
개발 편의를 위한 http 허용

### DIFF
--- a/cors-headers.conf
+++ b/cors-headers.conf
@@ -1,16 +1,16 @@
 # OPTIONS 요청 처리
 if ($request_method = 'OPTIONS') {
-    add_header 'Access-Control-Allow-Origin' '*';
-    add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
-    add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization, X-Requested-With';
-    add_header 'Access-Control-Allow-Credentials' 'true';
+    add_header 'Access-Control-Allow-Origin' 'http://localhost:3000' always;
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+    add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization, X-Requested-With' always;
+    add_header 'Access-Control-Allow-Credentials' 'true' always;
     return 204;
 }
 
 if ($request_method != 'OPTIONS') {
     # 공통 CORS 설정
-    add_header 'Access-Control-Allow-Origin' '*';
-    add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
-    add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization, X-Requested-With';
-    add_header 'Access-Control-Allow-Credentials' 'true';
+    add_header 'Access-Control-Allow-Origin' 'http://localhost:3000' always;
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS' always;
+    add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept, Authorization, X-Requested-With' always;
+    add_header 'Access-Control-Allow-Credentials' 'true' always;
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -107,13 +107,95 @@ http {
         }
     }
 
+    # # HTTP 서버 블록
+    # server {
+    #     listen 80;
+        
+    #     location / {
+    #         include /etc/nginx/common/cors-headers.conf;
+    #         return 301 https://$host$request_uri;
+    #     }
+    # }
+
     # HTTP 서버 블록
     server {
         listen 80;
         
         location / {
-            include /etc/nginx/common/cors-headers.conf;
-            return 301 https://$host$request_uri;
+            try_files $uri @frontend;
+
+            location /media/avatars/default.png {
+                include /etc/nginx/common/cors-headers.conf;
+                alias /media/avatars/default.png;
+                try_files $uri $uri/ = 404;
+            }
+            location /media/avatars/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_pass http://user;
+                proxy_set_header Host api-gateway;
+                proxy_set_header X-Real-IP $remote_addr;
+            }
+            location /api/user/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_pass http://user;
+				proxy_set_header Host api-gateway;
+            	proxy_set_header X-Real-IP $remote_addr;
+            }
+            location /api/chat/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_pass http://chat;
+				proxy_set_header Host api-gateway;
+            	proxy_set_header X-Real-IP $remote_addr;
+            }
+            location /api/game/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_pass http://game;
+				proxy_set_header Host api-gateway;
+            	proxy_set_header X-Real-IP $remote_addr;
+            }
+			location /ws/user/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_http_version 1.1;
+				proxy_set_header Upgrade $http_upgrade;
+				proxy_set_header Connection "upgrade";
+				proxy_read_timeout 86400;
+
+				# 쿼리스트링을 포함하여 전달
+				proxy_pass http://user$request_uri;
+				proxy_set_header Host api-gateway;
+				proxy_set_header X-Real-IP $remote_addr;
+            }
+			location /ws/chat/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_http_version 1.1;
+				proxy_set_header Upgrade $http_upgrade;
+				proxy_set_header Connection "upgrade";
+				proxy_read_timeout 86400;
+
+				# 쿼리스트링을 포함하여 전달
+				proxy_pass http://chat$request_uri;
+				proxy_set_header Host api-gateway;
+				proxy_set_header X-Real-IP $remote_addr;
+            }
+			location /ws/game/ {
+                include /etc/nginx/common/cors-headers.conf;
+                proxy_http_version 1.1;
+				proxy_set_header Upgrade $http_upgrade;
+				proxy_set_header Connection "upgrade";
+				proxy_read_timeout 86400;
+
+				# 쿼리스트링을 포함하여 전달
+				proxy_pass http://game$request_uri;
+				proxy_set_header Host api-gateway;
+				proxy_set_header X-Real-IP $remote_addr;
+            }
+        }
+        location @frontend {
+            proxy_pass http://frontend;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
 }


### PR DESCRIPTION
## 🔧 변경 내용 (What)

* 자가 서명된 인증서(Self-signed certificate)에 대한 브라우저 차단 문제를 회피하기 위해
  기존에 HTTP 요청을 HTTPS로 리다이렉트하던 로직을 제거하고,
  **HTTP 요청도 직접 서빙**하도록 변경했습니다.

---

## 🎯 변경 배경 (Why)

* 개발 환경에서는 자가 서명 인증서를 사용 중이며,
* 일부 브라우저(특히 Chrome 기반)에서 HTTPS 접속 시 보안 경고 또는 차단 발생
* 이로 인해 **프론트엔드/백엔드 기능 테스트가 불편**한 상황 발생
* 따라서 개발 단계에서만 HTTP 요청을 별도의 리다이렉션 없이 바로 처리할 수 있도록 설정